### PR TITLE
Code editing

### DIFF
--- a/Neotoma_paper.Rmd
+++ b/Neotoma_paper.Rmd
@@ -385,7 +385,7 @@ mam.melt <- melt(compiled.mam,
                  na.rm = TRUE,
                  factorsAsStrings = TRUE)
 
-mam.melt$ageInterval <- factor(mam.melt$ageInterval, levels = periods)
+mam.melt <- transform(mam.melt, ageInterval = factor(ageInterval, levels = periods))
 
 mam.lat <- dcast(data = mam.melt, variable ~ ageInterval, value.var = 'lat' ,
                  fun.aggregate = mean, drop = TRUE)[,c(1, 3, 5, 6)]


### PR DESCRIPTION
Several fixes in the PR, which hopefully simplify the R code used in chunks.
1. `top.pinus` was returning from two locations. This is not good (in general) form so I simplified this to a single (implicit) return
2. use `subset()` for its intended purpose. Simplifies the subsetting for sample age and longitude
3. Pandoc will sensibly render `--` as an en dash, the correct typographical mark to separate two numbers.
4. use `transform()` to simplify the coercion to factor
5. minor indentation fix
