### PR TITLE
Remove explicit loading of knitr

### DIFF
--- a/Neotoma_paper.Rmd
+++ b/Neotoma_paper.Rmd
@@ -80,13 +80,11 @@ A researcher is interested in finding the pollen record for Marion Lake, in Brit
 ```{r load-pkgs-1-code, echo = FALSE, warning = FALSE, message = FALSE}
 library("neotoma")
 suppressPackageStartupMessages(library("analogue"))
-library("knitr")
 ```
 
 ```{r load-pkgs-1}
 library("neotoma")
 library("analogue")
-library("knitr")
 
 marion <- get_site(sitename = 'Marion Lake%')
 louise <- get_site(sitename = 'Louise Pond%')


### PR DESCRIPTION
**knitr** is not needed by the reader to follow the paper or use **neotoma** so we shouldn't explicitly load it in the code chunks. Previously this would have broken the `Makefile` but now that `knitr::kabel()` is not used to render tables and we use `knitr::opts_chunk$set()` (i.e. explicitly reference the knitr namespace) we should be OK.

To fully round this out, the `Makefile` _should_ be changed to load `library("knitr")` explicitly when calling `Rscript`, but I'll leave that for others to handle if they want.

There is some discussion of this point in #14.
